### PR TITLE
Refactor IngredientWidget and update tests

### DIFF
--- a/app/ui/pages/add_recipes/add_recipes.py
+++ b/app/ui/pages/add_recipes/add_recipes.py
@@ -134,7 +134,7 @@ class AddRecipes(QWidget):
         self.ingredients_frame.addWidget(widget)
 
     def _remove_ingredient(self, widget):
-        self.ingredients_frame.layout().removeWidget(widget)
+        self.ingredients_frame.removeWidget(widget)
         widget.deleteLater()
         self.ingredients_frame.update()
 

--- a/app/ui/pages/add_recipes/ingredient_widget.py
+++ b/app/ui/pages/add_recipes/ingredient_widget.py
@@ -15,12 +15,13 @@ from app.core.services.ingredient_service import IngredientService
 from app.ui.components.inputs import ComboBox, SmartLineEdit
 from app.ui.helpers import clear_error_styles, dynamic_validation
 from app.ui.widgets import CTToolButton
+from app.ui.components.layout.widget_frame import WidgetFrame
 
 # ── Constants ───────────────────────────────────────────────────────────────────
 FIXED_HEIGHT = 32  # fixed height for input fields in the ingredient widget
 
 # ── Class Definition ────────────────────────────────────────────────────────────
-class IngredientWidget(QWidget):
+class IngredientWidget(WidgetFrame):
     add_ingredient_requested = Signal(QWidget)
     remove_ingredient_requested = Signal(QWidget)
     ingredient_validated = Signal(dict)
@@ -35,40 +36,45 @@ class IngredientWidget(QWidget):
             removable (bool): If True, the widget will have a remove button.
             parent (QWidget, optional): Parent widget for this ingredient widget.
         """
-        super().__init__(parent)
+        super().__init__(
+            title=None,
+            layout=QGridLayout,
+            margins=(0, 0, 0, 0),
+            spacing=0,
+            parent=parent,
+        )
         self.setObjectName("IngredientWidget")
-        self.ingredient_service = IngredientService() # instantiate IngredientService
+        self.ingredient_service = IngredientService()  # instantiate IngredientService
+        self.exact_match = None
         self._setup_ui()
         self.setup_event_logic()
-        self.exact_match = None
 
     def _setup_ui(self):
         """Sets up the UI components and layout for the ingredient widget."""
-        self.grid_layout = QGridLayout(self)
-        self.setLayout(self.grid_layout)
+        self.grid_layout = self.getLayout()
 
         self.le_quantity = QLineEdit(self)
         self.le_quantity.setPlaceholderText("Qty.")
-        self.grid_layout.addWidget(self.le_quantity, 0, 0, 1, 1)
+        self.addWidget(self.le_quantity, 0, 0, 1, 1)
 
         self.scb_unit = ComboBox(
             list_items  = MEASUREMENT_UNITS,
             placeholder = "Unit"
         )
-        self.grid_layout.addWidget(self.scb_unit, 0, 1, 1, 1)
+        self.addWidget(self.scb_unit, 0, 1, 1, 1)
 
         all_ingredient_names = self.ingredient_service.list_all_ingredient_names()
         self.scb_ingredient_name = SmartLineEdit(
             list_items  = all_ingredient_names,
             placeholder = "Ingredient Name",
         )
-        self.grid_layout.addWidget(self.scb_ingredient_name, 0, 2, 1, 1)
+        self.addWidget(self.scb_ingredient_name, 0, 2, 1, 1)
 
         self.scb_ingredient_category = ComboBox(
             list_items  = INGREDIENT_CATEGORIES,
             placeholder = "Category"
         )
-        self.grid_layout.addWidget(self.scb_ingredient_category, 0, 3, 1, 1)
+        self.addWidget(self.scb_ingredient_category, 0, 3, 1, 1)
 
         self.btn_ico_subtract = CTToolButton(
             file_path = INGREDIENT_WIDGET["ICON_SUBTRACT"],
@@ -76,7 +82,7 @@ class IngredientWidget(QWidget):
             variant   = INGREDIENT_WIDGET["DYNAMIC"]
         )
         self.btn_ico_subtract.setFixedWidth(FIXED_HEIGHT) # square button
-        self.grid_layout.addWidget(self.btn_ico_subtract, 0, 4, 1, 1)
+        self.addWidget(self.btn_ico_subtract, 0, 4, 1, 1)
 
         self.btn_ico_add = CTToolButton(
             file_path = INGREDIENT_WIDGET["ICON_ADD"],
@@ -84,7 +90,7 @@ class IngredientWidget(QWidget):
             variant   = INGREDIENT_WIDGET["DYNAMIC"]
         )
         self.btn_ico_add.setFixedWidth(FIXED_HEIGHT)  # square button
-        self.grid_layout.addWidget(self.btn_ico_add, 0, 5, 1, 1)
+        self.addWidget(self.btn_ico_add, 0, 5, 1, 1)
 
         # set column stretch factors: qty, unit, category = 1; name = 3; buttons = 0
         self.grid_layout.setColumnStretch(0, 1)  # Qty

--- a/tests/ui/pages/test_ingredient_widget.py
+++ b/tests/ui/pages/test_ingredient_widget.py
@@ -1,0 +1,60 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+from pytestqt.qtbot import QtBot
+
+import importlib.util
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+spec = importlib.util.spec_from_file_location(
+    "ingredient_widget",
+    ROOT_DIR / "app" / "ui" / "pages" / "add_recipes" / "ingredient_widget.py",
+)
+ingredient_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ingredient_module)
+IngredientWidget = ingredient_module.IngredientWidget
+
+
+@pytest.fixture
+def ingredient_widget(qtbot: QtBot) -> IngredientWidget:
+    widget = IngredientWidget()
+    qtbot.addWidget(widget)
+    return widget
+
+
+def test_emit_ingredient_data(ingredient_widget: IngredientWidget, qtbot: QtBot):
+    ingredient_widget.le_quantity.setText("1.5")
+    ingredient_widget.scb_unit.setCurrentText("cup")
+    ingredient_widget.scb_ingredient_name.line_edit.setText("Sugar")
+    ingredient_widget.scb_ingredient_category.setCurrentText("baking")
+
+    with qtbot.waitSignal(ingredient_widget.ingredient_validated) as blocker:
+        ingredient_widget.emit_ingredient_data()
+
+    payload = blocker.args[0]
+    assert payload["quantity"] == 1.5
+    assert payload["unit"] == "cup"
+    assert payload["ingredient_name"] == "Sugar"
+    assert payload["ingredient_category"] == "baking"
+
+
+def test_add_ingredient_signal(ingredient_widget: IngredientWidget, qtbot: QtBot):
+    with qtbot.waitSignals([ingredient_widget.ingredient_validated, ingredient_widget.add_ingredient_requested]):
+        qtbot.mouseClick(ingredient_widget.btn_ico_add, Qt.LeftButton)
+
+
+def test_remove_ingredient_signal(qtbot: QtBot):
+    container = QWidget()
+    layout = QVBoxLayout(container)
+    w1 = IngredientWidget()
+    w2 = IngredientWidget()
+    layout.addWidget(w1)
+    layout.addWidget(w2)
+    qtbot.addWidget(container)
+
+    with qtbot.waitSignal(w2.remove_ingredient_requested):
+        qtbot.mouseClick(w2.btn_ico_subtract, Qt.LeftButton)


### PR DESCRIPTION
## Summary
- refactor `IngredientWidget` to inherit from `WidgetFrame`
- adjust `AddRecipes` to use new widget interface
- add unit tests for `IngredientWidget` signals and data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68579fe62c8883269d1a3ef471524251