### PR TITLE
Fix filter and sort in recipe viewer

### DIFF
--- a/app/ui/pages/view_recipes/view_recipes.py
+++ b/app/ui/pages/view_recipes/view_recipes.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (QCheckBox, QHBoxLayout, QLayout, QScrollArea,
 from app.config import RECIPE_CATEGORIES, SORT_OPTIONS
 from app.core.data.models.recipe import Recipe
 from app.core.services.recipe_service import RecipeService
+from app.core.dtos.recipe_dtos import RecipeFilterDTO
 from app.ui.components.inputs import ComboBox
 from app.ui.components.recipe_card.constants import LayoutSize
 from app.ui.components.recipe_card.recipe_card import RecipeCard
@@ -104,11 +105,13 @@ class ViewRecipes(QWidget):
 
         self.clear_recipe_display()
 
-        recipes = RecipeService.list_filtered(
+        filter_dto = RecipeFilterDTO(
             recipe_category=recipe_category,
             sort_by=sort,
             favorites_only=favorites_only,
         )
+
+        recipes = RecipeService.list_filtered(filter_dto)
 
         for recipe in recipes:
             slot = RecipeCard(LayoutSize.MEDIUM, parent=self.scroll_container)


### PR DESCRIPTION
## Summary
- use `RecipeFilterDTO` when loading filtered recipes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685804d26d908326b725b234867e7058