### PR TITLE
Fix upload image path

### DIFF
--- a/app/core/dtos/recipe_dtos.py
+++ b/app/core/dtos/recipe_dtos.py
@@ -28,6 +28,7 @@ class RecipeCreateDTO(BaseModel):
     total_time: Optional[int] = None
     servings: Optional[int] = None
     directions: Optional[str] = None
+    image_path: Optional[str] = None
     ingredients: List[RecipeIngredientInputDTO] = []
 
 class RecipeFilterDTO(BaseModel):

--- a/app/ui/components/images/__init__.py
+++ b/app/ui/components/images/__init__.py
@@ -1,0 +1,1 @@
+from .upload_recipe_image import UploadRecipeImage

--- a/app/ui/components/images/upload_recipe_image.py
+++ b/app/ui/components/images/upload_recipe_image.py
@@ -4,7 +4,6 @@ UploadRecipeImage widget for uploading and cropping recipe images.
 """
 
 # ── Imports ─────────────────────────────────────────────────────────────────────
-import tempfile
 import uuid
 from pathlib import Path
 
@@ -21,7 +20,7 @@ from app.ui.helpers.ui_helpers import make_overlay
 from app.ui.widgets import CTToolButton, RoundedImage
 
 # ── Constants ───────────────────────────────────────────────────────────────────
-TEMP_IMAGE_DIR = Path(AppPaths.TEMP_CROP_DIR)
+IMAGE_SAVE_DIR = Path(AppPaths.RECIPE_IMAGES_DIR)
 
 # ── Class Definition ────────────────────────────────────────────────────────────
 class UploadRecipeImage(QWidget):
@@ -107,9 +106,12 @@ class UploadRecipeImage(QWidget):
             DebugLogger().log("Cropped pixmap is null, not saving.", "warning")
             return
 
-        # save the cropped QPixmap to a temporary file
-        unique_filename = f"cropped_{uuid.uuid4().hex}.png" # save as PNG for transparency
-        temp_image_path = TEMP_IMAGE_DIR / unique_filename
+        # ensure the destination directory exists
+        IMAGE_SAVE_DIR.mkdir(parents=True, exist_ok=True)
+
+        # save the cropped QPixmap to the recipe images directory
+        unique_filename = f"recipe_{uuid.uuid4().hex}.png"  # save as PNG for transparency
+        temp_image_path = IMAGE_SAVE_DIR / unique_filename
         
         try:
             if cropped_pixmap.save(str(temp_image_path), "PNG"):
@@ -147,14 +149,8 @@ class UploadRecipeImage(QWidget):
 
     def clear_image(self):
         """Resets the widget to show the upload button, clearing any displayed image."""
-        if self.selected_image_path:
-            # optionally, delete the temporary cropped image file
-            try:
-                if self.selected_image_path.exists():
-                    self.selected_image_path.unlink()
-                    DebugLogger().log(f"Deleted temp cropped image: {self.selected_image_path}", "info")
-            except Exception as e:
-                DebugLogger().log(f"Error deleting temp image {self.selected_image_path}: {e}", "error")
+
+        # Do not delete the image file here because it may be referenced by a saved recipe
         
         self.selected_image_path = None
         self.original_selected_file_path = None

--- a/app/ui/pages/add_recipes/add_recipes.py
+++ b/app/ui/pages/add_recipes/add_recipes.py
@@ -18,7 +18,7 @@ from app.ui.components.layout import WidgetFrame
 from app.ui.helpers import clear_error_styles, dynamic_validation
 
 from .ingredient_widget import IngredientWidget
-from .upload_recipe_image import UploadRecipeImage
+from app.ui.components.images.upload_recipe_image import UploadRecipeImage
 
 
 # ── Class Definition ────────────────────────────────────────────────────────────
@@ -122,13 +122,13 @@ class AddRecipes(QWidget):
 
     def _connect_signals(self):
         self.btn_save.clicked.connect(self.save_recipe)
-        """ self.btn_upload_image.image_uploaded.connect(self._update_image_path)
-        
+        self.btn_upload_image.image_uploaded.connect(self._update_image_path)
+
         dynamic_validation(self.le_recipe_name, NAME_VALIDATOR)
         dynamic_validation(self.le_servings, INT_VALIDATOR)
-        
+
         self.cb_recipe_category.selection_validated.connect(lambda: clear_error_styles(self.cb_recipe_category))
-        self.cb_meal_type.selection_validated.connect(lambda: clear_error_styles(self.cb_meal_type)) """
+        self.cb_meal_type.selection_validated.connect(lambda: clear_error_styles(self.cb_meal_type))
         self.te_directions.textChanged.connect(lambda: clear_error_styles(self.te_directions))
 
     def _add_ingredient(self, removable=True):

--- a/tests/dev/my_test_app.py
+++ b/tests/dev/my_test_app.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QGridLayout, QLineEdit, QMainWindow, QPushButton, 
     QVBoxLayout, QWidget, QLabel)
 from app.ui.pages.add_recipes.ingredient_widget import IngredientWidget
-from app.ui.pages.add_recipes.upload_recipe_image import UploadRecipeImage
+from app.ui.components.images.upload_recipe_image import UploadRecipeImage
 
 from app.config import (INGREDIENT_CATEGORIES, INGREDIENT_WIDGET,
                         MEASUREMENT_UNITS, STYLES)


### PR DESCRIPTION
## Summary
- save cropped recipe images to `recipe_images` directory
- avoid deleting recipe images on form reset
- move `UploadRecipeImage` widget to `app/ui/components/images`
- hook image upload signal in AddRecipes
- update imports for new location

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68581d0f80208326811e9bf6806240c1