### PR TITLE
Move IngredientWidget into forms package

### DIFF
--- a/app/ui/components/forms/__init__.py
+++ b/app/ui/components/forms/__init__.py
@@ -1,2 +1,3 @@
 from .recipe_form import RecipeForm
 from .form_field import FormField, LineEditField, ComboBoxField
+from .ingredient_widget import IngredientWidget

--- a/app/ui/components/forms/ingredient_widget.py
+++ b/app/ui/components/forms/ingredient_widget.py
@@ -1,4 +1,4 @@
-"""app/ui/pages/add_recipes/ingredient_widget.py
+"""app/ui/components/forms/ingredient_widget.py
 
 IngredientWidget for managing individual ingredients in recipes.
 """
@@ -55,6 +55,7 @@ class IngredientWidget(WidgetFrame):
     def _setup_ui(self):
         """Sets up the UI components and layout for the ingredient widget."""
         self.grid_layout = self.getLayout()
+        self.grid_layout.setAlignment(Qt.AlignTop)
 
         self.le_quantity = QLineEdit(self)
         self.le_quantity.setPlaceholderText("Qty.")

--- a/app/ui/pages/add_recipes/add_recipes.py
+++ b/app/ui/pages/add_recipes/add_recipes.py
@@ -17,7 +17,7 @@ from app.ui.components.forms  import RecipeForm
 from app.ui.components.layout import WidgetFrame
 from app.ui.helpers import clear_error_styles, dynamic_validation
 
-from .ingredient_widget import IngredientWidget
+from app.ui.components.forms import IngredientWidget
 from app.ui.components.images.upload_recipe_image import UploadRecipeImage
 
 

--- a/tests/dev/my_test_app.py
+++ b/tests/dev/my_test_app.py
@@ -5,7 +5,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QGridLayout, QLineEdit, QMainWindow, QPushButton, 
     QVBoxLayout, QWidget, QLabel)
-from app.ui.pages.add_recipes.ingredient_widget import IngredientWidget
+from app.ui.components.forms import IngredientWidget
 from app.ui.components.images.upload_recipe_image import UploadRecipeImage
 
 from app.config import (INGREDIENT_CATEGORIES, INGREDIENT_WIDGET,

--- a/tests/ui/pages/test_ingredient_widget.py
+++ b/tests/ui/pages/test_ingredient_widget.py
@@ -12,7 +12,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[3]
 spec = importlib.util.spec_from_file_location(
     "ingredient_widget",
-    ROOT_DIR / "app" / "ui" / "pages" / "add_recipes" / "ingredient_widget.py",
+    ROOT_DIR / "app" / "ui" / "components" / "forms" / "ingredient_widget.py",
 )
 ingredient_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(ingredient_module)


### PR DESCRIPTION
## Summary
- align IngredientWidget grid to top and move to `components/forms`
- update imports to new location
- fix test paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685830be7a60832686afb55dcc0f42d5