### PR TITLE
Fix RecipeSelection dialog init bug

### DIFF
--- a/app/ui/components/dialogs/recipe_selection.py
+++ b/app/ui/components/dialogs/recipe_selection.py
@@ -16,11 +16,18 @@ from app.ui.components.dialogs.dialog_window import DialogWindow
 
 # ── Class Definition ────────────────────────────────────────────────────────────
 class RecipeSelection(DialogWindow):
-    """
-    A dialog that displays a list of available recipes for selection.
-    """
-    def __init__(self, recipes: List[Recipe], parent=None):
-        super().__init__(parent)
+    """Dialog that allows the user to choose a recipe from a list."""
+
+    def __init__(self, recipes: List[Recipe], parent=None) -> None:
+        # ``DialogWindow``'s constructor expects width/height parameters and does
+        # not take ``parent`` positionally. Passing the parent as the first
+        # argument caused ``int(parent)`` to be evaluated when the base class
+        # called ``resize`` which raised the reported ``int()`` TypeError.
+        super().__init__(width=400, height=500, window_title="Select a Recipe")
+
+        if parent is not None:
+            self.setParent(parent)
+
         self._recipes = recipes
         self._selected_recipe: Optional[Recipe] = None
 


### PR DESCRIPTION
## Summary
- ensure RecipeSelection dialog initializes width/height correctly
- set parent separately to avoid int conversion error

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1, cannot import name 'field_validator')*

------
https://chatgpt.com/codex/tasks/task_e_68585a71365c8326a31f87c4ebc0b2fc