### PR TITLE
Extend ComboBox click area

### DIFF
--- a/app/ui/components/inputs/combobox.py
+++ b/app/ui/components/inputs/combobox.py
@@ -8,7 +8,7 @@ and emits signals when a valid selection is made.
 # ── Imports ─────────────────────────────────────────────────────────────────────
 from typing import Sequence
 
-from PySide6.QtCore import QStringListModel, Qt, Signal
+from PySide6.QtCore import QEvent, QStringListModel, Qt, Signal
 from PySide6.QtWidgets import QCompleter, QHBoxLayout, QLineEdit, QWidget
 
 from app.config import CUSTOM_COMBOBOX
@@ -58,6 +58,8 @@ class ComboBox(QWidget):
         self.line_edit.setPlaceholderText(placeholder)
         self.line_edit.setCompleter(self.completer)
         self.line_edit.setReadOnly(True)
+        self.line_edit.installEventFilter(self)
+        self.installEventFilter(self)
 
         # ── List Button ──
         self.cb_btn = CTToolButton(
@@ -147,3 +149,13 @@ class ComboBox(QWidget):
         if text not in items:
             items.append(text)
             self.model.setStringList(items)
+
+    # ------------------------------------------------------------------
+    def eventFilter(self, obj: QWidget, event: QEvent) -> bool:
+        """Expand the popup when the widget or line edit is clicked."""
+        if event.type() == QEvent.MouseButtonPress:
+            if obj in (self, self.line_edit):
+                self._show_popup()
+                # allow normal processing to keep focus behavior
+                return False
+        return super().eventFilter(obj, event)

--- a/tests/ui/components/inputs/test_combobox.py
+++ b/tests/ui/components/inputs/test_combobox.py
@@ -70,3 +70,8 @@ class TestComboBox:
         """Test adding an existing item."""
         combobox.addItem("Apple")
         assert combobox.model.rowCount() == 3
+
+    def test_popup_expands_on_click(self, combobox: ComboBox, qtbot: QtBot):
+        """Popup should be visible when clicking anywhere on the widget."""
+        qtbot.mouseClick(combobox.line_edit, Qt.LeftButton)
+        assert combobox.completer.popup().isVisible()


### PR DESCRIPTION
## Summary
- expand popup on mouse press for ComboBox widget
- ensure clicking line edit triggers popup
- test popup expansion when widget is clicked

## Testing
- `pytest -q` *(fails: libEGL.so.1 and pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68585f9b27b48326b85f4e1016c6b4a4