### PR TITLE
Add dashboard grid scaffolding

### DIFF
--- a/app/ui/pages/dashboard/__init__.py
+++ b/app/ui/pages/dashboard/__init__.py
@@ -1,8 +1,15 @@
-"""
-Initialization file for the app.dashboard package.
+"""Initialization for dashboard components."""
 
-Contains the Dashboard class and its associated UI components.
-"""
-
-# Import the dashboard logic
 from .dashboard import Dashboard
+from .components.dashboard_grid import DashboardGrid
+from .components.dashboard_widget import DashboardWidget, WidgetConfig
+from .components.widget_size import WidgetSize
+
+__all__ = [
+    "Dashboard",
+    "DashboardGrid",
+    "DashboardWidget",
+    "WidgetConfig",
+    "WidgetSize",
+]
+

--- a/app/ui/pages/dashboard/components/__init__.py
+++ b/app/ui/pages/dashboard/components/__init__.py
@@ -1,0 +1,15 @@
+"""Dashboard component classes."""
+
+from .dashboard_grid import DashboardGrid
+from .dashboard_widget import DashboardWidget, WidgetConfig
+from .grid_overlay import GridOverlay
+from .widget_size import WidgetSize
+
+__all__ = [
+    "DashboardGrid",
+    "DashboardWidget",
+    "WidgetConfig",
+    "GridOverlay",
+    "WidgetSize",
+]
+

--- a/app/ui/pages/dashboard/components/dashboard_grid.py
+++ b/app/ui/pages/dashboard/components/dashboard_grid.py
@@ -1,0 +1,49 @@
+"""Container widget that positions dashboard widgets on a fixed grid."""
+
+from __future__ import annotations
+
+from typing import List
+
+from PySide6.QtCore import QSize
+from PySide6.QtWidgets import QWidget
+
+from .dashboard_widget import DashboardWidget, WidgetConfig
+from .grid_overlay import GridOverlay
+
+
+class DashboardGrid(QWidget):
+    """Holds DashboardWidget instances arranged on a static grid."""
+
+    GRID_ROWS = 6
+    GRID_COLS = 9
+    CELL_SIZE = 100
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.widgets: List[DashboardWidget] = []
+        self.overlay = GridOverlay(self.CELL_SIZE, self.GRID_ROWS, self.GRID_COLS, self)
+        self.overlay.resize(self.size())
+
+    def add_dashboard_widget(self, widget: DashboardWidget) -> None:
+        """Add a widget to the grid and position it."""
+        self.widgets.append(widget)
+        widget.setParent(self)
+        widget.raise_()
+        self._position_widget(widget)
+
+    # ── Internal Helpers ───────────────────────────────────────────────────────
+    def _position_widget(self, widget: DashboardWidget) -> None:
+        cfg = widget.config
+        width = cfg.size.cols * self.CELL_SIZE
+        height = cfg.size.rows * self.CELL_SIZE
+        x = cfg.col * self.CELL_SIZE
+        y = cfg.row * self.CELL_SIZE
+        widget.setGeometry(x, y, width, height)
+
+    def resizeEvent(self, event):  # noqa: D401 - Qt override
+        """Resize overlay along with the grid."""
+        self.overlay.resize(self.size())
+        for widget in self.widgets:
+            self._position_widget(widget)
+        super().resizeEvent(event)
+

--- a/app/ui/pages/dashboard/components/dashboard_widget.py
+++ b/app/ui/pages/dashboard/components/dashboard_widget.py
@@ -1,0 +1,37 @@
+"""Base class for dashboard widgets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QFrame, QLabel, QVBoxLayout
+
+from .widget_size import WidgetSize
+
+
+@dataclass
+class WidgetConfig:
+    widget_type: str
+    row: int
+    col: int
+    size: WidgetSize
+
+
+class DashboardWidget(QFrame):
+    """A simple placeholder widget that knows its grid placement."""
+
+    def __init__(self, config: WidgetConfig, parent=None) -> None:
+        super().__init__(parent)
+        self.config = config
+        self.setObjectName("DashboardWidget")
+        self.setFrameShape(QFrame.StyledPanel)
+        self.setStyleSheet("background-color: #DDD; border-radius: 8px;")
+
+        label = QLabel(config.widget_type)
+        label.setAlignment(Qt.AlignCenter)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(label)
+

--- a/app/ui/pages/dashboard/components/grid_overlay.py
+++ b/app/ui/pages/dashboard/components/grid_overlay.py
@@ -1,0 +1,33 @@
+"""Transparent overlay that draws the dashboard grid."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import QWidget
+
+
+class GridOverlay(QWidget):
+    """Overlay widget drawing grid cells with rounded corners."""
+
+    def __init__(self, cell_size: int, rows: int, cols: int, parent=None) -> None:
+        super().__init__(parent)
+        self.cell_size = cell_size
+        self.rows = rows
+        self.cols = cols
+        self.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.hide()
+
+    def paintEvent(self, event):  # noqa: D401 - simple painting
+        """Paint the grid."""
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        color = QColor(0, 0, 0, 40)
+        painter.setPen(color)
+        for row in range(self.rows):
+            for col in range(self.cols):
+                x = col * self.cell_size
+                y = row * self.cell_size
+                rect = (x, y, self.cell_size, self.cell_size)
+                painter.drawRoundedRect(*rect, 6, 6)
+        painter.end()
+        super().paintEvent(event)
+

--- a/app/ui/pages/dashboard/components/widget_size.py
+++ b/app/ui/pages/dashboard/components/widget_size.py
@@ -1,0 +1,31 @@
+"""Enumeration for predefined dashboard widget sizes."""
+
+from __future__ import annotations
+
+from enum import Enum
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Size:
+    rows: int
+    cols: int
+
+
+class WidgetSize(Enum):
+    """Valid widget sizes in grid cells."""
+
+    SIZE_1x1 = Size(1, 1)
+    SIZE_1x2 = Size(1, 2)
+    SIZE_2x1 = Size(2, 1)
+    SIZE_2x2 = Size(2, 2)
+    SIZE_3x1 = Size(3, 1)
+    SIZE_4x3 = Size(4, 3)
+
+    @property
+    def rows(self) -> int:
+        return self.value.rows
+
+    @property
+    def cols(self) -> int:
+        return self.value.cols

--- a/app/ui/pages/dashboard/dashboard.py
+++ b/app/ui/pages/dashboard/dashboard.py
@@ -1,25 +1,36 @@
-"""app/ui/pages/dashboard/dashboard.py
+"""Dashboard page with simple grid layout."""
 
-Placeholder class for the Dashboard screen.
-"""
+from __future__ import annotations
 
-# ── Imports ─────────────────────────────────────────────────────────────────────
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+# ── Imports ────────────────────────────────────────────────────────────────────
+from PySide6.QtWidgets import QVBoxLayout, QWidget
+
+from .components.dashboard_grid import DashboardGrid
+from .components.dashboard_widget import DashboardWidget, WidgetConfig
+from .components.widget_size import WidgetSize
 
 
-# ── Class Definition ────────────────────────────────────────────────────────────
+# ── Class Definition ───────────────────────────────────────────────────────────
 class Dashboard(QWidget):
-    """Placeholder class for the Dashboard screen."""
+    """Dashboard screen composed of a grid of widgets."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         super().__init__(parent)
-        
-        # Initialize & Setup UI
-        self.setObjectName("Dashboard")
 
         self.setObjectName("Dashboard")
         self.setMinimumSize(984, 818)
 
         self.layout = QVBoxLayout(self)
-        self.layout.setContentsMargins(0, 0, 0, 0)  
+        self.layout.setContentsMargins(0, 0, 0, 0)
+
+        self.grid = DashboardGrid(self)
+        self.layout.addWidget(self.grid)
+
+        # ── Dummy Widgets for Initial Phase ──
+        w1 = DashboardWidget(WidgetConfig("Widget A", 0, 0, WidgetSize.SIZE_2x2))
+        w2 = DashboardWidget(WidgetConfig("Widget B", 0, 2, WidgetSize.SIZE_1x2))
+        w3 = DashboardWidget(WidgetConfig("Widget C", 2, 0, WidgetSize.SIZE_3x1))
+
+        for widget in (w1, w2, w3):
+            self.grid.add_dashboard_widget(widget)
+


### PR DESCRIPTION
## Summary
- implement core dashboard components
- show simple grid-based layout with placeholder widgets

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1, pydantic missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859e6bad74883269892a985f8a76466