### PR TITLE
Add dashboard grid placeholder components

### DIFF
--- a/app/ui/pages/dashboard/__init__.py
+++ b/app/ui/pages/dashboard/__init__.py
@@ -1,8 +1,10 @@
 """
-Initialization file for the app.dashboard package.
+Initialization file for the dashboard package.
 
-Contains the Dashboard class and its associated UI components.
+Exposes the Dashboard class and supporting grid widgets.
 """
 
-# Import the dashboard logic
 from .dashboard import Dashboard
+from .dashboard_grid import DashboardGrid
+from .dashboard_widget import DashboardWidget
+from .widget_sizes import WidgetSize

--- a/app/ui/pages/dashboard/dashboard_grid.py
+++ b/app/ui/pages/dashboard/dashboard_grid.py
@@ -1,0 +1,75 @@
+"""app/ui/pages/dashboard/dashboard_grid.py
+
+Widget responsible for manual placement of dashboard widgets using a fixed grid.
+"""
+
+# ── Imports ────────────────────────────────────────────
+from PySide6.QtCore import QRect
+from PySide6.QtGui import QColor, QPainter, QPen
+from PySide6.QtWidgets import QWidget
+
+from .dashboard_widget import DashboardWidget
+from .widget_sizes import WidgetSize
+
+
+class DashboardGrid(QWidget):
+    """A simple 9x6 grid layout for displaying DashboardWidgets."""
+
+    ROWS = 6
+    COLS = 9
+    CELL_SIZE = 100
+    SPACING = 10
+    GRID_RADIUS = 8
+
+    def __init__(self, parent=None, dev_mode: bool = False) -> None:
+        super().__init__(parent)
+        self.setObjectName("DashboardGrid")
+        self.dev_mode = dev_mode
+
+        self.setFixedSize(self.grid_width(), self.grid_height())
+        self._place_dummy_widgets()
+
+    # ── Public API ──────────────────────────────────
+    def grid_width(self) -> int:
+        """Return the total width of the grid in pixels."""
+        return self.COLS * self.CELL_SIZE + (self.COLS - 1) * self.SPACING
+
+    def grid_height(self) -> int:
+        """Return the total height of the grid in pixels."""
+        return self.ROWS * self.CELL_SIZE + (self.ROWS - 1) * self.SPACING
+
+    def paintEvent(self, event) -> None:  # type: ignore[override]
+        super().paintEvent(event)
+        if not self.dev_mode:
+            return
+
+        painter = QPainter(self)
+        pen = QPen(QColor(0, 0, 0, 40))
+        painter.setPen(pen)
+        for row in range(self.ROWS):
+            for col in range(self.COLS):
+                x = col * (self.CELL_SIZE + self.SPACING)
+                y = row * (self.CELL_SIZE + self.SPACING)
+                rect = QRect(x, y, self.CELL_SIZE, self.CELL_SIZE)
+                painter.drawRoundedRect(rect, self.GRID_RADIUS, self.GRID_RADIUS)
+
+    # ── Internal Methods ──────────────────────────────────────
+    def _place_widget(self, widget: DashboardWidget, row: int, col: int) -> None:
+        width = widget.size.cols() * self.CELL_SIZE + (widget.size.cols() - 1) * self.SPACING
+        height = widget.size.rows() * self.CELL_SIZE + (widget.size.rows() - 1) * self.SPACING
+        x = col * (self.CELL_SIZE + self.SPACING)
+        y = row * (self.CELL_SIZE + self.SPACING)
+        widget.setParent(self)
+        widget.setGeometry(x, y, width, height)
+        widget.show()
+
+    def _place_dummy_widgets(self) -> None:
+        self._place_widget(
+            DashboardWidget("w1", "Recipe Card", WidgetSize.ONE_BY_TWO), 1, 1
+        )
+        self._place_widget(
+            DashboardWidget("w2", "Header Banner", WidgetSize.THREE_BY_ONE), 0, 3
+        )
+        self._place_widget(
+            DashboardWidget("w3", "Carousel", WidgetSize.FOUR_BY_THREE), 2, 4
+        )

--- a/app/ui/pages/dashboard/dashboard_widget.py
+++ b/app/ui/pages/dashboard/dashboard_widget.py
@@ -1,0 +1,31 @@
+"""app/ui/pages/dashboard/dashboard_widget.py
+
+Base class for widgets placed on the dashboard grid.
+"""
+
+# ── Imports ────────────────────────────────────────────
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QFrame
+
+from .widget_sizes import WidgetSize
+
+
+class DashboardWidget(QFrame):
+    """Simple placeholder widget displayed on the dashboard."""
+
+    def __init__(self, widget_id: str, title: str, size: WidgetSize, parent=None):
+        super().__init__(parent)
+        self.widget_id = widget_id
+        self.title = title
+        self.size = size
+
+        self.setObjectName("DashboardWidget")
+        self._build_ui()
+
+    # ── Internal Methods ──────────────────────────────────────
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        label = QLabel(self.title)
+        label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(label)

--- a/app/ui/pages/dashboard/widget_sizes.py
+++ b/app/ui/pages/dashboard/widget_sizes.py
@@ -1,0 +1,24 @@
+"""app/ui/pages/dashboard/widget_sizes.py
+
+Enum defining the available widget sizes for the dashboard grid.
+"""
+
+# ── Imports ────────────────────────────────────────────
+from enum import Enum
+
+
+class WidgetSize(Enum):
+    """Available widget sizes expressed as (cols, rows)."""
+
+    ONE_BY_ONE = (1, 1)
+    ONE_BY_TWO = (1, 2)
+    THREE_BY_ONE = (3, 1)
+    FOUR_BY_THREE = (4, 3)
+
+    def cols(self) -> int:
+        """Return the width of the widget in grid columns."""
+        return self.value[0]
+
+    def rows(self) -> int:
+        """Return the height of the widget in grid rows."""
+        return self.value[1]

--- a/tests/ui/pages/test_dashboard_grid.py
+++ b/tests/ui/pages/test_dashboard_grid.py
@@ -1,0 +1,34 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication
+from pytestqt.qtbot import QtBot
+
+from app.ui.pages.dashboard import DashboardGrid, DashboardWidget, WidgetSize
+
+
+def test_widget_size_helpers():
+    assert WidgetSize.ONE_BY_TWO.cols() == 1
+    assert WidgetSize.ONE_BY_TWO.rows() == 2
+
+
+def test_place_widget_geometry(qtbot: QtBot):
+    grid = DashboardGrid(dev_mode=False)
+    qtbot.addWidget(grid)
+    widget = DashboardWidget("id", "Test", WidgetSize.ONE_BY_TWO)
+    grid._place_widget(widget, 1, 1)
+    expected_x = 1 * (DashboardGrid.CELL_SIZE + DashboardGrid.SPACING)
+    expected_y = 1 * (DashboardGrid.CELL_SIZE + DashboardGrid.SPACING)
+    expected_w = WidgetSize.ONE_BY_TWO.cols() * DashboardGrid.CELL_SIZE + (WidgetSize.ONE_BY_TWO.cols() - 1) * DashboardGrid.SPACING
+    expected_h = WidgetSize.ONE_BY_TWO.rows() * DashboardGrid.CELL_SIZE + (WidgetSize.ONE_BY_TWO.rows() - 1) * DashboardGrid.SPACING
+    assert widget.geometry().x() == expected_x
+    assert widget.geometry().y() == expected_y
+    assert widget.geometry().width() == expected_w
+    assert widget.geometry().height() == expected_h
+
+
+def test_dummy_widget_count(qtbot: QtBot):
+    grid = DashboardGrid(dev_mode=False)
+    qtbot.addWidget(grid)
+    widgets = grid.findChildren(DashboardWidget)
+    assert len(widgets) == 3


### PR DESCRIPTION
## Summary
- implement `WidgetSize`, `DashboardWidget`, and `DashboardGrid` for the dashboard
- expose new classes in the dashboard package
- add tests for grid placement logic

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6859f41f4b988326836c1db0f0a7d408