### PR TITLE
Improve AddRecipe form keyboard navigation

### DIFF
--- a/app/style_manager/stylesheets/components/combobox.qss
+++ b/app/style_manager/stylesheets/components/combobox.qss
@@ -8,6 +8,11 @@
     border-radius: 6px;
 }
 
+#ComboBox:focus {
+    border: 1px solid {ACCENT_PRIMARY};
+    outline: none;
+}
+
 #ComboBox #LineEdit {
     background-color: {BACKGROUND_WIDGET};
     color: {FONT_COLOR_CONTRAST};

--- a/app/ui/components/inputs/combobox.py
+++ b/app/ui/components/inputs/combobox.py
@@ -9,7 +9,8 @@ and emits signals when a valid selection is made.
 from typing import Sequence
 
 from PySide6.QtCore import QEvent, QStringListModel, Qt, Signal
-from PySide6.QtWidgets import QCompleter, QHBoxLayout, QLineEdit, QWidget
+from PySide6.QtWidgets import (QApplication, QCompleter, QHBoxLayout, QLineEdit,
+                               QWidget)
 
 from app.config import CUSTOM_COMBOBOX
 from app.core.utils import DebugLogger
@@ -60,6 +61,8 @@ class ComboBox(QWidget):
         self.line_edit.setReadOnly(True)
         self.line_edit.installEventFilter(self)
         self.installEventFilter(self)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self.setFocusProxy(self.line_edit)
 
         # ── List Button ──
         self.cb_btn = CTToolButton(
@@ -73,6 +76,7 @@ class ComboBox(QWidget):
         # ── Signals ──
         self.line_edit.textChanged.connect(self._on_text_changed)
         self.cb_btn.clicked.connect(self._show_popup)
+        self.completer.activated[str].connect(self.setCurrentText)
 
         self._build_ui()
 
@@ -152,10 +156,29 @@ class ComboBox(QWidget):
 
     # ------------------------------------------------------------------
     def eventFilter(self, obj: QWidget, event: QEvent) -> bool:
-        """Expand the popup when the widget or line edit is clicked."""
-        if event.type() == QEvent.MouseButtonPress:
-            if obj in (self, self.line_edit):
+        """Handle focus and click events."""
+        if obj in (self, self.line_edit):
+            if event.type() == QEvent.MouseButtonPress:
                 self._show_popup()
-                # allow normal processing to keep focus behavior
                 return False
+            if event.type() == QEvent.FocusIn:
+                self._show_popup()
+            if event.type() == QEvent.FocusOut:
+                self.completer.popup().hide()
         return super().eventFilter(obj, event)
+
+    def keyPressEvent(self, event):
+        if event.key() in (Qt.Key_Down, Qt.Key_Up):
+            if not self.completer.popup().isVisible():
+                self._show_popup()
+            QApplication.sendEvent(self.completer.popup(), event)
+            return
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            if self.completer.popup().isVisible():
+                current = self.completer.popup().currentIndex()
+                if current.isValid():
+                    text = self.model.data(current, Qt.DisplayRole)
+                    self.setCurrentText(text)
+                self.completer.popup().hide()
+                return
+        super().keyPressEvent(event)

--- a/app/ui/pages/add_recipes/add_recipes.py
+++ b/app/ui/pages/add_recipes/add_recipes.py
@@ -121,6 +121,16 @@ class AddRecipes(QWidget):
         self.lyt_main.addLayout(
             self.lyt_main_content)  # add main content layout to main layout
 
+        # ── Keyboard Navigation ──
+        QWidget.setTabOrder(self.le_recipe_name.input_widget,
+                            self.cb_recipe_category.input_widget)
+        QWidget.setTabOrder(self.cb_recipe_category.input_widget,
+                            self.le_time.input_widget)
+        QWidget.setTabOrder(self.le_time.input_widget,
+                            self.cb_meal_type.input_widget)
+        QWidget.setTabOrder(self.cb_meal_type.input_widget,
+                            self.le_servings.input_widget)
+
     def _connect_signals(self):
         self.btn_save.clicked.connect(self.save_recipe)
         self.btn_upload_image.image_uploaded.connect(self._update_image_path)
@@ -131,6 +141,11 @@ class AddRecipes(QWidget):
         self.cb_recipe_category.selection_validated.connect(lambda: clear_error_styles(self.cb_recipe_category))
         self.cb_meal_type.selection_validated.connect(lambda: clear_error_styles(self.cb_meal_type))
         self.te_directions.textChanged.connect(lambda: clear_error_styles(self.te_directions))
+
+    def showEvent(self, event):
+        """Set initial focus when the widget is shown."""
+        super().showEvent(event)
+        self.le_recipe_name.setFocus()
 
     def _add_ingredient(self, removable=True):
         widget = IngredientWidget(removable=removable)

--- a/tests/ui/components/inputs/test_combobox.py
+++ b/tests/ui/components/inputs/test_combobox.py
@@ -75,3 +75,15 @@ class TestComboBox:
         """Popup should be visible when clicking anywhere on the widget."""
         qtbot.mouseClick(combobox.line_edit, Qt.LeftButton)
         assert combobox.completer.popup().isVisible()
+
+    def test_popup_expands_on_focus(self, combobox: ComboBox, qtbot: QtBot):
+        """Popup should open when the widget gains focus."""
+        combobox.setFocus()
+        assert combobox.completer.popup().isVisible()
+
+    def test_keyboard_navigation_selects_item(self, combobox: ComboBox, qtbot: QtBot):
+        """Down arrow then Enter should choose the first item."""
+        combobox.setFocus()
+        qtbot.keyPress(combobox, Qt.Key_Down)
+        qtbot.keyPress(combobox, Qt.Key_Return)
+        assert combobox.currentText() == INITIAL_ITEMS[0]


### PR DESCRIPTION
## Summary
- set tab order for AddRecipe form fields
- focus recipe name field when Add Recipes page opens
- allow ComboBox focus and keyboard navigation
- highlight ComboBox when focused
- test keyboard navigation for ComboBox

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685ae0da947883269ffacd4f98b9bf58