### PR TITLE
Wrap RecipeForm in WidgetFrame

### DIFF
--- a/app/ui/components/forms/recipe_form.py
+++ b/app/ui/components/forms/recipe_form.py
@@ -12,21 +12,20 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QGridLayout, QWidget, QLabel
 
 from app.ui.components.forms.form_field import LineEditField, ComboBoxField
-from app.ui.components.layout.widget_frame import WidgetFrame
 from app.ui.helpers.ui_helpers import set_fixed_height_for_layout_widgets
 
 from app.config import RECIPE_CATEGORIES, MEAL_CATEGORIES
 
 # ── Class Definition ────────────────────────────────────────────────────────────
-class RecipeForm(WidgetFrame):
+class RecipeForm(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
-        super().__init__(
-            title   = "Recipe Details", 
-            layout  = QGridLayout, 
-            spacing = 10,
-            parent  = parent, 
-        )
-        self.setObjectName("WidgetFrame") # for styling purposes
+        super().__init__(parent)
+        self.setObjectName("RecipeForm")
+
+        # ── Configure layout ──
+        self._layout = QGridLayout(self)
+        self._layout.setContentsMargins(10, 10, 10, 10)
+        self._layout.setSpacing(10)
 
         # create form fields for recipe details
         self.le_recipe_name = LineEditField(
@@ -59,15 +58,15 @@ class RecipeForm(WidgetFrame):
             placeholder="e.g. 4 servings...",
         ) 
 
-        # add widgets to the recipe details frame
-        self.addWidget(self.le_recipe_name, 0, 0, 1, 2)  # row 1
-        self.addWidget(self.cb_recipe_category, 1, 0, 1, 1)  # row 2
-        self.addWidget(self.le_time, 1, 1, 1, 1)
-        self.addWidget(self.cb_meal_type, 2, 0, 1, 1)  # row 3
-        self.addWidget(self.le_servings, 2, 1, 1, 1)
+        # add widgets to the form layout
+        self._layout.addWidget(self.le_recipe_name, 0, 0, 1, 2)  # row 1
+        self._layout.addWidget(self.cb_recipe_category, 1, 0, 1, 1)  # row 2
+        self._layout.addWidget(self.le_time, 1, 1, 1, 1)
+        self._layout.addWidget(self.cb_meal_type, 2, 0, 1, 1)  # row 3
+        self._layout.addWidget(self.le_servings, 2, 1, 1, 1)
 
         set_fixed_height_for_layout_widgets(
-            layout = self.getLayout(), 
-            height = FIXED_HEIGHT, 
-            skip   = (QLabel)
+            layout = self._layout,
+            height = FIXED_HEIGHT,
+            skip   = (QLabel,)
         )

--- a/app/ui/pages/add_recipes/add_recipes.py
+++ b/app/ui/pages/add_recipes/add_recipes.py
@@ -68,7 +68,14 @@ class AddRecipes(QWidget):
         self.lyt_recipe_details = QHBoxLayout()
         self.lyt_recipe_details.setContentsMargins(0, 0, 0, 0)
 
+        # recipe details form wrapped in a WidgetFrame
+        self.recipe_details_frame = WidgetFrame(
+            title="Recipe Details",
+            layout=QVBoxLayout,
+        )
         self.recipe_form = RecipeForm()  # custom form for recipe details
+        self.recipe_details_frame.addWidget(self.recipe_form)
+
         # expose form fields for convenience
         self.le_recipe_name = self.recipe_form.le_recipe_name
         self.cb_recipe_category = self.recipe_form.cb_recipe_category
@@ -77,7 +84,7 @@ class AddRecipes(QWidget):
         self.le_servings = self.recipe_form.le_servings
 
         self.lyt_recipe_details.addWidget(
-            self.recipe_form)  # add recipe form to recipe details layout
+            self.recipe_details_frame)  # add recipe form frame to layout
 
         # ── Buttons ──
         self.lyt_buttons =QVBoxLayout()  # vertical layout for buttons


### PR DESCRIPTION
## Summary
- refactor `RecipeForm` to inherit from `QWidget`
- create a surrounding `WidgetFrame` for the recipe form in `AddRecipes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca74774a083269f8ae015fd45e8a1