### PR TITLE
Fix recipe card ID handling

### DIFF
--- a/app/ui/pages/meal_planner/meal_widget.py
+++ b/app/ui/pages/meal_planner/meal_widget.py
@@ -91,13 +91,18 @@ class MealWidget(QWidget):
         """
         # ── Normalize Input ──
         if not isinstance(recipe_id, int):
-            rid = getattr(recipe_id, "id", recipe_id)
+            # ``RecipeCard`` widgets may emit themselves instead of a plain
+            # integer ID.  Normalize those cases by introspecting for a
+            # ``recipe()`` method and falling back to any ``id`` attribute.
+            recipe_obj = getattr(recipe_id, "recipe", None)
+            if callable(recipe_obj):
+                recipe_obj = recipe_obj()
+
+            rid = getattr(recipe_id, "id", recipe_obj)
+
             try:
                 recipe_id = int(rid)
             except (TypeError, ValueError):
-                recipe_obj = getattr(recipe_id, "recipe", None)
-                if callable(recipe_obj):
-                    recipe_obj = recipe_obj()
                 try:
                     recipe_id = int(getattr(recipe_obj, "id", 0))
                 except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- relax `update_recipe_selection` to gracefully handle RecipeCard widgets emitting themselves instead of an int

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc68a08bc8326af212c2fc5481d13