### PR TITLE
Fix RecipeSelection dialog visibility

### DIFF
--- a/app/ui/components/dialogs/dialog_window.py
+++ b/app/ui/components/dialogs/dialog_window.py
@@ -36,14 +36,15 @@ class DialogWindow(QDialog):
         start_geometry: Initial geometry of the dialog.
     """
 
-    def __init__(self, width: int = 1330, height: int = 800, window_title: str =""):
+    def __init__(self, width: int = 1330, height: int = 800, window_title: str = "", parent=None):
         """Initializes the DialogWindow.
 
         Args:
             width (int, optional): Initial width of the dialog. Defaults to 1330.
             height (int, optional): Initial height of the dialog. Defaults to 800.
+            parent (QWidget, optional): Parent widget that owns the dialog.
         """
-        super().__init__()
+        super().__init__(parent)
         # ── Properties ──
         self.setWindowFlags(Qt.FramelessWindowHint | Qt.Dialog)
         # self.setAttribute(Qt.WA_TranslucentBackground)

--- a/app/ui/components/dialogs/recipe_selection.py
+++ b/app/ui/components/dialogs/recipe_selection.py
@@ -21,9 +21,7 @@ class RecipeSelection(DialogWindow):
     A dialog that displays a list of available recipes for selection.
     """
     def __init__(self, recipes: List[Recipe], parent=None):
-        super().__init__(width=400, height=500)
-        if parent is not None:
-            self.setParent(parent)
+        super().__init__(width=400, height=500, parent=parent)
         self._recipes = recipes
         self._selected_recipe: Optional[Recipe] = None
         DebugLogger.log(f"[RecipeSelection] Initialized with {len(recipes)} recipes", "debug")


### PR DESCRIPTION
## Summary
- allow parent injection in `DialogWindow`
- pass parent correctly when creating `RecipeSelection`

## Testing
- `pytest -q` *(fails: pydantic `field_validator` and `pytestqt` missing)*

------
https://chatgpt.com/codex/tasks/task_e_685da551d7488326a5a9fa65a2484de7