### PR TITLE
Fix removal of specific ingredient in AddRecipes

### DIFF
--- a/app/ui/pages/add_recipes/add_recipes.py
+++ b/app/ui/pages/add_recipes/add_recipes.py
@@ -157,9 +157,9 @@ class AddRecipes(QWidget):
         self.ingredients_frame.addWidget(widget)
 
     def _remove_ingredient(self, widget):
-        container = widget.parent()
-        self.ingredients_frame.removeWidget(container)
-        container.deleteLater()
+        """Remove the specified ingredient widget from the frame."""
+        self.ingredients_frame.removeWidget(widget)
+        widget.deleteLater()
         self.ingredients_frame.update()
         if widget in self.ingredient_widgets:
             self.ingredient_widgets.remove(widget)


### PR DESCRIPTION
## Summary
- fix `_remove_ingredient` to delete only the targeted widget
- ensure project tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e05aca7ac8326b1794311d8bd909a