### PR TITLE
Fix ESC key closing app

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -273,4 +273,11 @@ class MainWindow(QDialog):
 
         self.setGeometry(new_rect)
 
+    def keyPressEvent(self, event):
+        """Ignore the Escape key to prevent accidental app closure."""
+        if event.key() == Qt.Key_Escape:
+            event.ignore()
+            return
+        super().keyPressEvent(event)
+
 


### PR DESCRIPTION
## Summary
- prevent Escape from closing MainWindow by overriding `keyPressEvent`

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e060d1b108326a61424e656022dc1