### PR TITLE
Refactor dialog imports

### DIFF
--- a/app/ui/components/images/__init__.py
+++ b/app/ui/components/images/__init__.py
@@ -1,8 +1,9 @@
 # app.ui.components.image package
 
 from .avatar_loader import AvatarLoader
-from .image_cropper import ImageCropper, MIN_CROP_DIM_ORIGINAL
+from .image_cropper import ImageCropper
 from .upload_recipe_image import UploadRecipeImage
+from app.ui.helpers.dialog_helpers import MIN_CROP_DIM_ORIGINAL
 
 __all__ = [
     "AvatarLoader",

--- a/app/ui/components/images/image_cropper.py
+++ b/app/ui/components/images/image_cropper.py
@@ -5,10 +5,10 @@ Image cropping tool with interactive rectangle for selecting crop area.
 # ── Imports ─────────────────────────────────────────────────────────────────────
 from PySide6.QtCore import QPointF, QRectF, QSizeF, Qt, Signal, QRect
 from PySide6.QtGui import QMouseEvent, QPainter, QPainterPath, QPen, QPixmap, QColor
-from PySide6.QtWidgets import QLabel,QSizePolicy
+from PySide6.QtWidgets import QLabel, QSizePolicy
+from app.ui.helpers.dialog_helpers import MIN_CROP_DIM_ORIGINAL
 
 # ── Constants ───────────────────────────────────────────────────────────────────
-MIN_CROP_DIM_ORIGINAL = 280  # Minimum crop dimension on the original image
 HANDLE_SIZE = 10  # Visual size of resize handles
 HANDLE_INTERACTION_OFFSET = 4 # Extend interaction area for handles slightly
 

--- a/app/ui/components/images/upload_recipe_image.py
+++ b/app/ui/components/images/upload_recipe_image.py
@@ -16,7 +16,6 @@ from PySide6.QtWidgets import (
 from app.config import UPLOAD_RECIPE_IMAGE
 from app.config.paths import AppPaths
 from app.core.dev_tools import DebugLogger
-from app.ui.components.dialogs import CropDialog
 from app.ui.helpers.ui_helpers import make_overlay
 from app.ui.components.widgets import CTToolButton, RoundedImage
 
@@ -94,6 +93,7 @@ class UploadRecipeImage(QWidget):
 
     def _launch_crop_dialog(self, image_path: str):
         """Lauches the RecipeImageCropDialog with the selected image."""
+        from app.ui.components.dialogs.crop_dialog import CropDialog
         crop_dialog = CropDialog(image_path, self)
         crop_dialog.crop_finalized.connect(self._handle_crop_saved)
         crop_dialog.select_new_image_requested.connect(self._handle_select_new_from_crop_dialog)

--- a/app/ui/helpers/__init__.py
+++ b/app/ui/helpers/__init__.py
@@ -1,9 +1,20 @@
 # app/ui/helpers/__init__.py
 
 from .types import ThemedIcon as ThemedIconProtocol  # Rename to avoid conflict
-from .ui_helpers import (create_fixed_wrapper, create_framed_layout,
-                         create_hbox_with_widgets, create_vbox_with_widgets,
-                         make_overlay, center_on_screen)
+from .ui_helpers import (
+    create_fixed_wrapper,
+    create_framed_layout,
+    create_hbox_with_widgets,
+    create_vbox_with_widgets,
+    make_overlay,
+    center_on_screen,
+)
+from .dialog_helpers import (
+    MIN_CROP_DIM_ORIGINAL,
+    SELECT_NEW_IMAGE_CODE,
+    load_pixmap_or_warn,
+    build_crop_buttons,
+)
 from .validation import (apply_error_style, clear_error_styles,
                          dynamic_validation)
 
@@ -12,9 +23,21 @@ __all__ = [
     "ThemedIconProtocol",
 
     # From ui_helpers.py
-    "create_fixed_wrapper", "create_framed_layout", "create_hbox_with_widgets",
-    "create_vbox_with_widgets", "make_overlay", "center_on_screen",
+    "create_fixed_wrapper",
+    "create_framed_layout",
+    "create_hbox_with_widgets",
+    "create_vbox_with_widgets",
+    "make_overlay",
+    "center_on_screen",
+
+    # From dialog_helpers.py
+    "MIN_CROP_DIM_ORIGINAL",
+    "SELECT_NEW_IMAGE_CODE",
+    "load_pixmap_or_warn",
+    "build_crop_buttons",
 
     # From validation.py
-    "apply_error_style", "clear_error_styles", "dynamic_validation"
+    "apply_error_style",
+    "clear_error_styles",
+    "dynamic_validation",
 ]

--- a/app/ui/helpers/dialog_helpers.py
+++ b/app/ui/helpers/dialog_helpers.py
@@ -1,0 +1,49 @@
+"""app/ui/helpers/dialog_helpers.py
+
+Shared helpers for dialog components such as crop dialogs.
+"""
+
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import (
+    QDialog, QHBoxLayout, QMessageBox, QPushButton,
+    QSizePolicy, QSpacerItem
+)
+
+# Minimum crop dimension required on the original image
+MIN_CROP_DIM_ORIGINAL = 280
+
+# Custom result code used by CropDialog when the user wants to choose
+# a different file.
+SELECT_NEW_IMAGE_CODE = QDialog.DialogCode.Rejected + 1
+
+
+def load_pixmap_or_warn(path: str, parent=None) -> QPixmap:
+    """Return a QPixmap from ``path`` or show a warning dialog if it fails."""
+    pixmap = QPixmap(path)
+    if pixmap.isNull() and parent is not None:
+        QMessageBox.warning(parent, "Image Error", f"Could not load image: {path}")
+    return pixmap
+
+
+def build_crop_buttons() -> tuple[QPushButton, QPushButton, QPushButton, QHBoxLayout]:
+    """Create Select-New, Cancel and Save buttons with standard layout."""
+    btn_select_new = QPushButton("Select New Image")
+    btn_select_new.setObjectName("SelectNewButton")
+
+    btn_cancel = QPushButton("Cancel")
+    btn_cancel.setObjectName("CancelButton")
+
+    btn_save = QPushButton("Save Crop")
+    btn_save.setObjectName("SaveButton")
+    btn_save.setDefault(True)
+
+    layout = QHBoxLayout()
+    layout.setSpacing(10)
+    layout.addWidget(btn_select_new)
+    layout.addSpacerItem(
+        QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+    )
+    layout.addWidget(btn_cancel)
+    layout.addWidget(btn_save)
+
+    return btn_select_new, btn_cancel, btn_save, layout


### PR DESCRIPTION
## Summary
- centralize crop dialog helpers in `dialog_helpers`
- simplify `CropDialog` and lazily import it in `UploadRecipeImage`
- source crop constants from helper module

## Testing
- `pytest -q` *(fails: ImportError: qframelesswindow)*

------
https://chatgpt.com/codex/tasks/task_e_686327000a2c8326861ad817a0b227ab