### PR TITLE
Add SQLAlchemy ORM models and unit tests

### DIFF
--- a/app/core/data/sqlalchemy_base.py
+++ b/app/core/data/sqlalchemy_base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy ORM models."""
+    pass

--- a/app/core/sa/__init__.py
+++ b/app/core/sa/__init__.py
@@ -1,0 +1,5 @@
+from .ingredient import Ingredient
+from .recipe import Recipe
+from .recipe_ingredient import RecipeIngredient
+
+__all__ = ["Ingredient", "Recipe", "RecipeIngredient"]

--- a/app/core/sa/ingredient.py
+++ b/app/core/sa/ingredient.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.data.sqlalchemy_base import Base
+
+
+class Ingredient(Base):
+    __tablename__ = "ingredients"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+
+    recipes: Mapped[List["RecipeIngredient"]] = relationship(
+        back_populates="ingredient", cascade="all, delete-orphan"
+    )

--- a/app/core/sa/recipe.py
+++ b/app/core/sa/recipe.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.data.sqlalchemy_base import Base
+
+
+class Recipe(Base):
+    __tablename__ = "recipes"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), index=True)
+    instructions: Mapped[str] = mapped_column(Text, nullable=True)
+
+    ingredients: Mapped[List["RecipeIngredient"]] = relationship(
+        back_populates="recipe", cascade="all, delete-orphan"
+    )

--- a/app/core/sa/recipe_ingredient.py
+++ b/app/core/sa/recipe_ingredient.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.data.sqlalchemy_base import Base
+
+
+class RecipeIngredient(Base):
+    __tablename__ = "recipe_ingredients"
+
+    recipe_id: Mapped[int] = mapped_column(ForeignKey("recipes.id"), primary_key=True)
+    ingredient_id: Mapped[int] = mapped_column(ForeignKey("ingredients.id"), primary_key=True)
+    quantity: Mapped[str] = mapped_column(String(50), nullable=True)
+
+    recipe: Mapped["Recipe"] = relationship(back_populates="ingredients")
+    ingredient: Mapped["Ingredient"] = relationship(back_populates="recipes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from app.core.data.sqlalchemy_base import Base
+
+engine = create_engine("sqlite:///:memory:")
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture(scope="function")
+def db_session() -> Session:
+    """Provide a transactional scope around a series of operations."""
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)

--- a/tests/sa/test_models.py
+++ b/tests/sa/test_models.py
@@ -1,0 +1,27 @@
+from sqlalchemy.orm import Session
+
+from app.core.sa import Ingredient, Recipe, RecipeIngredient
+
+
+def test_create_ingredient(db_session: Session) -> None:
+    ingredient = Ingredient(name="Flour")
+    db_session.add(ingredient)
+    db_session.commit()
+
+    assert ingredient.id is not None
+    retrieved = db_session.get(Ingredient, ingredient.id)
+    assert retrieved.name == "Flour"
+
+
+def test_recipe_with_ingredient(db_session: Session) -> None:
+    recipe = Recipe(name="Bread")
+    ingredient = Ingredient(name="Flour")
+    link = RecipeIngredient(ingredient=ingredient, recipe=recipe, quantity="1 cup")
+    recipe.ingredients.append(link)
+
+    db_session.add(recipe)
+    db_session.commit()
+    db_session.refresh(recipe)
+
+    assert recipe.id is not None
+    assert recipe.ingredients[0].ingredient.name == "Flour"


### PR DESCRIPTION
## Summary
- add SQLAlchemy Declarative Base class
- implement ORM models for Ingredient, Recipe, and RecipeIngredient
- create fixtures for an in-memory SQLite DB
- add unit tests for the new ORM models

## Testing
- `pytest tests/sa/test_models.py -q`
- `pytest -q` *(fails: ImportError in UI tests due to missing Windows ctypes)*

------
https://chatgpt.com/codex/tasks/task_e_6863633d4fac8326acb9cfdb4e06135c