### PR TITLE
Add SQLAlchemy Declarative base

### DIFF
--- a/app/core/data/sqlalchemy_base.py
+++ b/app/core/data/sqlalchemy_base.py
@@ -1,0 +1,26 @@
+"""app/core/data/sqlalchemy_base.py
+
+Declarative base class for SQLAlchemy ORM models used across MealGenie.
+"""
+
+# ── Imports ────────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import DateTime
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.sql import func
+
+
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy models.
+
+    Provides a central metadata registry. Shared columns can be defined here to
+    appear on every table that inherits from this class.
+    """
+
+    # created_at: Mapped[datetime.datetime] = mapped_column(
+    #     DateTime(timezone=True), server_default=func.now()
+    # )
+    pass

--- a/app/ui/components/navigation/titlebar.py
+++ b/app/ui/components/navigation/titlebar.py
@@ -4,12 +4,8 @@ Title bar component for the main application window.
 """
 
 # ── Imports ───────────────────────────────────────────────────────────────
-import sys
+from qframelesswindow.utils.win32_utils import WindowsMoveResize as MoveResize
 
-if sys.platform.startswith("win"):
-    from qframelesswindow.utils.win32_utils import WindowsMoveResize as MoveResize
-else:
-    from qframelesswindow.utils.linux_utils import LinuxMoveResize as MoveResize
 from PySide6.QtCore import Qt, Signal, QPoint
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget

--- a/app/ui/components/navigation/titlebar.py
+++ b/app/ui/components/navigation/titlebar.py
@@ -4,7 +4,12 @@ Title bar component for the main application window.
 """
 
 # ── Imports ───────────────────────────────────────────────────────────────
-from qframelesswindow.utils.win32_utils import WindowsMoveResize as MoveResize
+import sys
+
+if sys.platform.startswith("win"):
+    from qframelesswindow.utils.win32_utils import WindowsMoveResize as MoveResize
+else:
+    from qframelesswindow.utils.linux_utils import LinuxMoveResize as MoveResize
 from PySide6.QtCore import Qt, Signal, QPoint
 from PySide6.QtGui import QMouseEvent
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget

--- a/app/ui/views/dashboard/__init__.py
+++ b/app/ui/views/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Dashboard view package."""
+
+from .dashboard import Dashboard
+
+__all__ = ["Dashboard"]

--- a/app/ui/views/meal_planner/__init__.py
+++ b/app/ui/views/meal_planner/__init__.py
@@ -1,0 +1,6 @@
+"""Meal planner view package."""
+
+from .meal_planner import MealPlanner
+
+__all__ = ["MealPlanner"]
+


### PR DESCRIPTION
## Summary
- add DeclarativeBase `Base`
- fix cross-platform import for `TitleBar`
- expose dashboard and meal planner classes

## Testing
- `python -m app.core.data.init_db`
- `PYTHONPATH=. QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686367c1d52c8326a6a9890323ca1f19