### PR TITLE
Add SQLAlchemy models

### DIFF
--- a/app/core/data/models/ingredient.py
+++ b/app/core/data/models/ingredient.py
@@ -1,0 +1,33 @@
+"""app/core/data/models/ingredient.py
+
+SQLAlchemy ORM model for ingredients.
+"""
+
+# ── Imports ────────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from .recipe_ingredient import RecipeIngredient
+
+from app.core.data.sqlalchemy_base import Base
+
+
+# ── Model Definition ───────────────────────────────────────────────────────
+class Ingredient(Base):
+    """Database model representing an ingredient."""
+
+    __tablename__ = "ingredients"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    ingredient_name: Mapped[str] = mapped_column(String, nullable=False)
+    ingredient_category: Mapped[str] = mapped_column(String, nullable=False)
+
+    recipes: Mapped[List["RecipeIngredient"]] = relationship(
+        back_populates="ingredient", cascade="all, delete-orphan"
+    )
+

--- a/app/core/data/models/recipe.py
+++ b/app/core/data/models/recipe.py
@@ -1,0 +1,44 @@
+"""app/core/data/models/recipe.py
+
+SQLAlchemy ORM model for recipes.
+"""
+
+# ── Imports ────────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import Boolean, DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+if TYPE_CHECKING:
+    from .recipe_ingredient import RecipeIngredient
+
+from app.core.data.sqlalchemy_base import Base
+
+
+# ── Model Definition ───────────────────────────────────────────────────────
+class Recipe(Base):
+    """Database model representing a cooking recipe."""
+
+    __tablename__ = "recipes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    recipe_name: Mapped[str] = mapped_column(String, nullable=False)
+    recipe_category: Mapped[str] = mapped_column(String, nullable=False)
+    meal_type: Mapped[str] = mapped_column(String, nullable=False, default="Dinner")
+    total_time: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    servings: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    directions: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    image_path: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    is_favorite: Mapped[bool] = mapped_column(Boolean, server_default="0", nullable=False)
+
+    ingredients: Mapped[List["RecipeIngredient"]] = relationship(
+        back_populates="recipe", cascade="all, delete-orphan"
+    )
+

--- a/app/core/data/models/recipe_ingredient.py
+++ b/app/core/data/models/recipe_ingredient.py
@@ -1,0 +1,34 @@
+"""app/core/data/models/recipe_ingredient.py
+
+Association table between recipes and ingredients.
+"""
+
+# ── Imports ────────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+if TYPE_CHECKING:
+    from .ingredient import Ingredient
+    from .recipe import Recipe
+
+from app.core.data.sqlalchemy_base import Base
+
+
+# ── Model Definition ───────────────────────────────────────────────────────
+class RecipeIngredient(Base):
+    """Association object linking a recipe to an ingredient."""
+
+    __tablename__ = "recipe_ingredients"
+
+    recipe_id: Mapped[int] = mapped_column(ForeignKey("recipes.id"), primary_key=True)
+    ingredient_id: Mapped[int] = mapped_column(ForeignKey("ingredients.id"), primary_key=True)
+    quantity: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    unit: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+    recipe: Mapped["Recipe"] = relationship(back_populates="ingredients")
+    ingredient: Mapped["Ingredient"] = relationship(back_populates="recipes")
+


### PR DESCRIPTION
## Summary
- create SQLAlchemy ORM models for Recipe, Ingredient, and RecipeIngredient
- use DeclarativeBase, mapped_column, and typed relationships

## Testing
- `pytest -q` *(fails: cannot import `field_validator`, missing `pytestqt`)*

------
https://chatgpt.com/codex/tasks/task_e_68636edf41d48326b1d5dfae915fa7e8