### PR TITLE
Add SQLAlchemy declarative base

### DIFF
--- a/app/core/data/sqlalchemy_base.py
+++ b/app/core/data/sqlalchemy_base.py
@@ -1,0 +1,25 @@
+"""app/core/data/sqlalchemy_base.py
+
+Declarative base class for all SQLAlchemy ORM models.
+
+This allows models across the application to share the same metadata.
+A timestamp mixin may be added here in the future.
+"""
+
+# ── Imports ──────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+# from datetime import datetime
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""
+
+    # 🔹 Shared timestamp columns (uncomment if needed)
+    # created_at: Mapped[datetime] = mapped_column(default_factory=datetime.utcnow)
+    # updated_at: Mapped[datetime] = mapped_column(
+    #     default_factory=datetime.utcnow,
+    #     onupdate=datetime.utcnow,
+    # )
+


### PR DESCRIPTION
## Summary
- create declarative SQLAlchemy base class for upcoming ORM models

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'field_validator' from 'pydantic', ModuleNotFoundError: No module named 'pytestqt')*

------
https://chatgpt.com/codex/tasks/task_e_68640e8845a08326ad2babe16111fabc