### PR TITLE
Add SQLAlchemy ORM models

### DIFF
--- a/app/core/data/models/__init__.py
+++ b/app/core/data/models/__init__.py
@@ -1,0 +1,7 @@
+"""ORM models for the MealGenie application."""
+
+from .recipe import Recipe
+from .ingredient import Ingredient
+from .recipe_ingredient import RecipeIngredient
+
+__all__ = ["Recipe", "Ingredient", "RecipeIngredient"]

--- a/app/core/data/models/ingredient.py
+++ b/app/core/data/models/ingredient.py
@@ -1,0 +1,28 @@
+"""app/core/data/models/ingredient.py
+
+SQLAlchemy ORM model for ingredients.
+"""
+
+# ── Imports ──────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+from typing import List
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.data.sqlalchemy_base import Base
+
+
+class Ingredient(Base):
+    """Represents a single ingredient."""
+
+    __tablename__ = "ingredients"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column("ingredient_name", String, nullable=False)
+
+    recipes: Mapped[List["RecipeIngredient"]] = relationship(
+        back_populates="ingredient", cascade="all, delete-orphan"
+    )
+

--- a/app/core/data/models/recipe.py
+++ b/app/core/data/models/recipe.py
@@ -1,0 +1,32 @@
+"""app/core/data/models/recipe.py
+
+SQLAlchemy ORM model for recipes.
+"""
+
+# ── Imports ──────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import Integer, String, Text, DateTime
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.data.sqlalchemy_base import Base
+
+
+class Recipe(Base):
+    """Represents a recipe stored in the database."""
+
+    __tablename__ = "recipes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column("recipe_name", String, nullable=False)
+    instructions: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default_factory=datetime.utcnow)
+
+    ingredients: Mapped[List["RecipeIngredient"]] = relationship(
+        back_populates="recipe", cascade="all, delete-orphan"
+    )
+
+

--- a/app/core/data/models/recipe_ingredient.py
+++ b/app/core/data/models/recipe_ingredient.py
@@ -1,0 +1,33 @@
+"""app/core/data/models/recipe_ingredient.py
+
+Association table linking recipes and ingredients.
+"""
+
+# ── Imports ──────────────────────────────────────────────────────────────
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.data.sqlalchemy_base import Base
+
+
+class RecipeIngredient(Base):
+    """Join table between :class:`Recipe` and :class:`Ingredient`."""
+
+    __tablename__ = "recipe_ingredients"
+
+    recipe_id: Mapped[int] = mapped_column(
+        ForeignKey("recipes.id"), primary_key=True
+    )
+    ingredient_id: Mapped[int] = mapped_column(
+        ForeignKey("ingredients.id"), primary_key=True
+    )
+    quantity: Mapped[Optional[float]] = mapped_column(Float)
+    unit: Mapped[Optional[str]] = mapped_column(String)
+
+    recipe: Mapped["Recipe"] = relationship(back_populates="ingredients")
+    ingredient: Mapped["Ingredient"] = relationship(back_populates="recipes")
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for recipes, ingredients and their association table
- expose ORM models via `app/core/data/models/__init__.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytestqt')*

------
https://chatgpt.com/codex/tasks/task_e_686419fd3ad88326bea0ff19f9e3fda2