### PR TITLE
Refactor RecipeService for SQLAlchemy sessions

### DIFF
--- a/app/core/data/models/recipe.py
+++ b/app/core/data/models/recipe.py
@@ -23,7 +23,7 @@ class Recipe(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column("recipe_name", String, nullable=False)
     instructions: Mapped[Optional[str]] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default_factory=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     ingredients: Mapped[List["RecipeIngredient"]] = relationship(
         back_populates="recipe", cascade="all, delete-orphan"

--- a/app/core/services/recipe_service.py
+++ b/app/core/services/recipe_service.py
@@ -4,16 +4,15 @@ This module provides the RecipeService class for transactional recipe operations
 """
 
 # ── Imports ─────────────────────────────────────────────────────────────────────
-import sqlite3
-
-from pydantic import ValidationError
+from sqlalchemy.orm import Session
 
 from .base_service import BaseService
-from app.core.models.ingredient import Ingredient
-from app.core.models.recipe import Recipe
-from app.core.models.recipe_ingredient import RecipeIngredient
+from app.core.models.recipe import Recipe as LegacyRecipe
+
+from app.core.data.models.recipe import Recipe as SARecipe
+from app.core.data.models.ingredient import Ingredient as SAIngredient
+from app.core.data.models.recipe_ingredient import RecipeIngredient as SARecipeIngredient
 from app.core.dtos import (
-    IngredientCreateDTO,
     RecipeCreateDTO,
     RecipeFilterDTO,
     RecipeIngredientInputDTO,
@@ -36,78 +35,46 @@ class RecipeService(BaseService):
     
     @staticmethod
     def create_recipe_with_ingredients(
-        recipe_dto: RecipeCreateDTO,  # Use the DTO instead of raw dict
-    ) -> Recipe:
-        """
-        Atomically create a recipe plus all ingredient links.
+        session: Session,
+        recipe_dto: RecipeCreateDTO,
+    ) -> SARecipe:
+        """Create a recipe and related ingredient links using ORM sessions."""
 
-        Args:
-            recipe_dto (RecipeCreateDTO): DTO containing recipe and ingredient data.
-        Returns:
-            Recipe: The created recipe object.
-        Raises:
-            DuplicateRecipeError: if a recipe with the same name+category already exists.
-            RecipeSaveError: if any validation or database error occurs.
-        """
-        # 1) Check for duplicate recipe before opening the transaction
-        if Recipe.exists(
-            recipe_name=recipe_dto.recipe_name,
-            recipe_category=recipe_dto.recipe_category
-        ):
+        # check for duplicates by name
+        existing = session.query(SARecipe).filter_by(name=recipe_dto.recipe_name).first()
+        if existing:
             raise DuplicateRecipeError(
-                f"Recipe '{recipe_dto.recipe_name}' in category '{recipe_dto.recipe_category}' already exists."
+                f"Recipe '{recipe_dto.recipe_name}' already exists."
             )
 
-        try:
-            # 2) Open a single connection/transaction
-            with RecipeService.connection_ctx() as conn:
-                # 3) Convert DTO → model, validate & save the recipe itself
-                #    model_dump(exclude={"ingredients"}) returns a dict that matches Recipe fields
-                recipe_data = recipe_dto.model_dump(exclude={"ingredients"})
-                recipe = Recipe.model_validate(recipe_data)
-                recipe.save(connection=conn)
+        recipe = SARecipe(
+            name=recipe_dto.recipe_name,
+            instructions=recipe_dto.directions,
+        )
 
-                # 4) Loop through each ingredient in the DTO, 
-                #    build an IngredientCreateDTO, and get_or_create via IngredientService
-                for ing_dto in recipe_dto.ingredients:
-                    if getattr(ing_dto, "existing_ingredient_id", None):
-                        ingredient = Ingredient.get(ing_dto.existing_ingredient_id)
-                    else:
-                        try:
-                            ing_create_dto = IngredientCreateDTO(
-                                ingredient_name=ing_dto.ingredient_name,
-                                ingredient_category=ing_dto.ingredient_category,
-                                quantity=ing_dto.quantity,
-                                unit=ing_dto.unit,
-                            )
-                        except ValidationError as ve:
-                            raise RecipeSaveError(
-                                f"Invalid ingredient data for '{ing_dto.ingredient_name}': {ve}"
-                            ) from ve
+        for ing_dto in recipe_dto.ingredients:
+            ingredient = None
+            if getattr(ing_dto, "existing_ingredient_id", None):
+                ingredient = session.get(SAIngredient, ing_dto.existing_ingredient_id)
 
-                        ingredient = IngredientService.get_or_create_ingredient(
-                            ing_create_dto,
-                            conn=conn
-                        )
+            if ingredient is None:
+                ingredient = IngredientService.get_or_create(session, ing_dto.ingredient_name)
 
-                    RecipeIngredient(
-                        recipe_id=recipe.id,
-                        ingredient_id=ingredient.id,
-                        quantity=ing_dto.quantity,
-                        unit=ing_dto.unit,
-                    ).save(connection=conn)
+            link = SARecipeIngredient(
+                quantity=ing_dto.quantity,
+                unit=ing_dto.unit,
+            )
+            link.ingredient = ingredient
+            recipe.ingredients.append(link)
 
-                # 6) Return the newly created Recipe model
-                return recipe
+        session.add(recipe)
+        session.commit()
+        session.refresh(recipe)
 
-        except (ValidationError, sqlite3.Error) as err:
-            # Wrap both Pydantic validation errors and SQLite errors
-            raise RecipeSaveError(
-                f"Unable to save recipe '{recipe_dto.recipe_name}': {err}"
-            ) from err
+        return recipe
 
     @staticmethod
-    def toggle_favorite(recipe_id: int) -> Recipe:
+    def toggle_favorite(recipe_id: int) -> LegacyRecipe:
         """
         Flip the is_favorite flag and persist.
         
@@ -118,7 +85,7 @@ class RecipeService(BaseService):
         Raises:
             ValueError: If no recipe with the given ID exists.
         """
-        recipe = Recipe.get(recipe_id)
+        recipe = LegacyRecipe.get(recipe_id)
         if not recipe:
             raise ValueError(f"No recipe with id={recipe_id}")
         recipe.is_favorite = not recipe.is_favorite
@@ -128,7 +95,7 @@ class RecipeService(BaseService):
     @staticmethod
     def list_filtered(
         filter_dto: RecipeFilterDTO
-    ) -> list[Recipe]:
+    ) -> list[LegacyRecipe]:
         """
         List all recipes, applying optional filters and sorting.
 
@@ -137,7 +104,7 @@ class RecipeService(BaseService):
         Returns:
             list[Recipe]: List of filtered and sorted Recipe objects.
         """
-        recs = Recipe.list_all()
+        recs = LegacyRecipe.list_all()
 
         # apply recipe category filter
         if filter_dto.recipe_category and filter_dto.recipe_category != "All":


### PR DESCRIPTION
## Summary
- update `Recipe` model default timestamp
- refactor `RecipeService.create_recipe_with_ingredients` to use SQLAlchemy sessions
- keep legacy methods working alongside new ORM

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'windll' from 'ctypes')*

------
https://chatgpt.com/codex/tasks/task_e_686423d1e3ac8326ba12bc3d4dcd2c6a