### PR TITLE
Add in-memory SQLAlchemy session fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""tests/conftest
+
+Pytest fixtures for database setup."""
+
+# ── Imports ─────────────────────────────────────────────────────────────────────
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from app.core.data.sqlalchemy_base import Base
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def db_session() -> Session:
+    """Provide a Session bound to an in-memory SQLite database."""
+    engine = create_engine("sqlite+pysqlite:///:memory:", echo=False)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)


### PR DESCRIPTION
## Summary
- add pytest fixture that sets up an in-memory database

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.core.data.sqlalchemy_base')*

------
https://chatgpt.com/codex/tasks/task_e_68642668699c8326b2072a1fa2f2c2bc